### PR TITLE
Fix piece placement bug

### DIFF
--- a/NineMensMorris/include/game.h
+++ b/NineMensMorris/include/game.h
@@ -34,7 +34,7 @@ public:
     void setPlayerTurnText(bool whitePiece);
     void setInstructionText(int turnNumber, bool captureMode = false);
 
-    virtual void checkForNewMill();
+    void checkForNewMill();
     void checkForFlying();
     void checkForPieceVictory();
     void checkForMovesVictory();
@@ -91,7 +91,7 @@ protected:
 private slots:
     void pieceCaptureAction(Piece *piece);
     void pieceSelectAction(Piece *piece);
-    void nextTurn(Piece *piece);
+    virtual void nextTurn(Piece *piece);
 
 };
 

--- a/NineMensMorris/include/singleplayergame.h
+++ b/NineMensMorris/include/singleplayergame.h
@@ -4,7 +4,6 @@
 #include "include/game.h"
 #include <stdlib.h>
 #include <time.h>
-#include <QDebug>
 
 class SinglePlayerGame : Game {
 public:

--- a/NineMensMorris/include/singleplayergame.h
+++ b/NineMensMorris/include/singleplayergame.h
@@ -4,6 +4,7 @@
 #include "include/game.h"
 #include <stdlib.h>
 #include <time.h>
+#include <QDebug>
 
 class SinglePlayerGame : Game {
 public:
@@ -17,7 +18,6 @@ public:
 
     void enableSelectPiece();
     void enableCapturePiece();
-    void checkForNewMill();
 
     void startNewTurn();
 private:
@@ -25,6 +25,8 @@ private:
     std::vector<int> availableSpaces;
     std::vector<int> availableSelect;
     std::vector<int> availableCapture;
+private slots:
+    void nextTurn(Piece *piece);
 };
 
 

--- a/NineMensMorris/src/game.cpp
+++ b/NineMensMorris/src/game.cpp
@@ -503,7 +503,7 @@ void Game::startNewTurn() {
 
     setTurnCountText(turnNumber);
     setPlayerTurnText(whiteTurn);
-    setInstructionText(turnNumber);
+    setInstructionText(turnNumber, captureMode);
 
     if (!phaseOneComplete) {
         if (turnNumber < 9) {

--- a/NineMensMorris/src/singleplayergame.cpp
+++ b/NineMensMorris/src/singleplayergame.cpp
@@ -162,14 +162,6 @@ void SinglePlayerGame::enableCapturePiece() {
     }
 }
 
-//Overrides function to add computer player capture
-void SinglePlayerGame::checkForNewMill() {
-    Game::checkForNewMill();
-    if ((whiteTurn == computerColorWhite) && captureMode) {
-        computerCapture();
-    }
-}
-
 //Overrides function to add computer move functionality
 void SinglePlayerGame::startNewTurn() {
     Game::startNewTurn();
@@ -178,10 +170,18 @@ void SinglePlayerGame::startNewTurn() {
             computerPhaseOneMove();
         } else if ((!whiteFlying && computerColorWhite) || (!blackFlying && !computerColorWhite)) {
             computerPhaseTwoMove();
-        } else {
+        } else if ((whiteFlying && computerColorWhite) || (blackFlying && !computerColorWhite)) {
             computerFlyingMove();
         }
     }
 }
 
-
+void SinglePlayerGame::nextTurn(Piece *piece) {
+    endTurn(piece);
+    checkForNewMill();
+    if (!captureMode) {
+        evaluateVictoryConditions();
+    } else if (whiteTurn == computerColorWhite) {
+        computerCapture();
+    }
+}


### PR DESCRIPTION
# Description

The computerCapture() call moved from the end of checkForMill() to the end of slot nextTurn(). Fixing bug where player pieces are automatically place in rapid succession after a mill is formed in phase one.

Issue #:
Card Title:

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] App.test
- [x] Other

**Test Configuration**:
* Dependencies changed:
* Test class name(s):
* Classes tested:

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules