### PR TITLE
Implement Surrender Game Mechanic

### DIFF
--- a/NineMensMorris/include/game.h
+++ b/NineMensMorris/include/game.h
@@ -21,16 +21,21 @@ public:
     Game(QGraphicsScene * scene);
     ~Game();
     QPushButton *menuButton;
+    QPushButton *surrenderButton;
+    QPushButton *playAgainButton;
+    QFont buttonFont;
     void pieceCleanup(std::vector<Piece*> &pieces);
     void boardCleanup(QGraphicsProxyWidget* proxyBoard);
     void spaceCleanup(std::vector<Space*> &spaces);
     void textItemCleanup();
+
 
     int getSpaceIndex(Space *space);
     void setAdjacentSpaces(Piece *piece, bool value);
     void setAllSpaceValidity(bool value);
     bool pieceInMill(Piece *piece);
 
+    void playAgain();
     void setTurnCountText(int turn);
     void setPlayerTurnText(bool whitePiece);
     void setInstructionText(int turnNumber, bool captureMode = false);
@@ -64,6 +69,8 @@ public:
     void endPhaseOne();
 
     QPushButton *returnMainMenu() {return menuButton;}
+    QPushButton *returnSurrenderButton() {return surrenderButton;}
+    QPushButton *returnPlayAgainButton() {return playAgainButton;}
 protected:
     QGraphicsScene *scene;
     Board *board;
@@ -94,7 +101,7 @@ private slots:
     void pieceCaptureAction(Piece *piece);
     void pieceSelectAction(Piece *piece);
     virtual void nextTurn(Piece *piece);
-
+    void surrenderGame();
 };
 
 #endif // GAME_H

--- a/NineMensMorris/include/gamemanager.h
+++ b/NineMensMorris/include/gamemanager.h
@@ -35,6 +35,8 @@ private slots:
     void switchBackToMainMenu();
     void switchBackToMainMenuSinglePlayer();
     void switchBackToMainMenuTwoPlayer();
+    void switchToSinglePlayerPlayAgain();
+    void switchToTwoPlayerPlayAgain();
 };
 
 #endif // GAMEMANAGER_H

--- a/NineMensMorris/include/singleplayergame.h
+++ b/NineMensMorris/include/singleplayergame.h
@@ -7,8 +7,8 @@
 
 class SinglePlayerGame : Game {
 public:
-    SinglePlayerGame(QGraphicsScene *scene, bool computerIsWhite);
 
+    SinglePlayerGame(QGraphicsScene *scene, bool computerIsWhite);
     void scanSpaces();
     void computerPhaseOneMove();
     void computerPhaseTwoMove();
@@ -20,6 +20,8 @@ public:
 
     void startNewTurn();
     QPushButton *returnMainMenu() {return menuButton;}
+    QPushButton *returnSurrenderButton() {return surrenderButton;}
+    QPushButton *returnPlayAgainButton() {return playAgainButton;}
 private:
     bool computerColorWhite;
     std::vector<int> availableSpaces;

--- a/NineMensMorris/src/game.cpp
+++ b/NineMensMorris/src/game.cpp
@@ -7,6 +7,7 @@ Game::~Game() {
     Game::spaceCleanup(spaceList);
     Game::textItemCleanup();
     scene->removeItem(board->graphicsProxyWidget());
+    scene->clear();
 }
 
 Game::Game(QGraphicsScene *scene) {
@@ -137,11 +138,19 @@ Game::Game(QGraphicsScene *scene) {
     scene->addItem(blackPieceText);
 
     menuButton = new QPushButton(QString("Main Menu"));
+    playAgainButton = new QPushButton(QString("Play Again?"));
+
     menuButton->setGeometry(325,800,150,50);
-    QFont buttonFont("comic sans MS", 14);
+    playAgainButton->setGeometry(325,750,150,50);
+    buttonFont = QFont("comic sans MS", 14);
+
     menuButton->setFont(buttonFont);
+    playAgainButton->setFont(buttonFont);
+
     menuButton->setStyleSheet("background-color: brown; color: #00DCDC; border-style: outset; border-width: 2px; border-radius: 3px; border-color: yellow; padding: 6px;");
+    playAgainButton->setStyleSheet("background-color: brown; color: #00DCDC; border-style: outset; border-width: 2px; border-radius: 3px; border-color: yellow; padding: 6px;");
     scene->addWidget(menuButton);
+
 }
 
 // Freeing up piece memory at the end of the game
@@ -364,8 +373,10 @@ void Game::evaluateVictoryConditions() {
     }
     if (whiteVictory) {
         instructionText->setPlainText("White Wins!");
+        scene->addWidget(playAgainButton);
     } else if (blackVictory) {
         instructionText->setPlainText("Black Wins!");
+        scene->addWidget(playAgainButton);
     }
     else {
         startNewTurn();
@@ -587,3 +598,14 @@ void Game::nextTurn(Piece *piece) {
         evaluateVictoryConditions();
     }
 }
+
+//surrenders game method, stops the game and allows for Computer to win
+void Game::surrenderGame() {
+    disableSelectPiece();
+    if(whiteTurn) {
+        blackVictory = true;
+    } else {
+        whiteVictory = true;
+    }
+    evaluateVictoryConditions();
+};

--- a/NineMensMorris/src/gamemanager.cpp
+++ b/NineMensMorris/src/gamemanager.cpp
@@ -41,7 +41,7 @@ void GameManager::switchTwoPlayerMode() {
     game = new Game(&gameScene);
     view.setScene(&gameScene);
     connect(game->returnMainMenu(),SIGNAL(clicked()),this,SLOT(switchBackToMainMenuTwoPlayer()));
-
+    connect(game->returnPlayAgainButton(),SIGNAL(clicked()),this,SLOT(switchToTwoPlayerPlayAgain()));
 }
 
 //this method begins a single player game with the user being white
@@ -52,6 +52,7 @@ void GameManager::switchComputerPlayerModeWhite() {
 
     //this connect catches the signal if the main menu button is clicked during the game
     connect(computerGame->returnMainMenu(),SIGNAL(clicked()),this,SLOT(switchBackToMainMenuSinglePlayer()));
+    connect(computerGame->returnPlayAgainButton(), SIGNAL(clicked()),this,SLOT(switchToSinglePlayerPlayAgain()));
 }
 
 void GameManager::switchComputerPlayerModeBlack() {
@@ -61,6 +62,7 @@ void GameManager::switchComputerPlayerModeBlack() {
 
     //this connect catches the signal if the main menu button is clicked during the game
     connect(computerGame->returnMainMenu(),SIGNAL(clicked()),this,SLOT(switchBackToMainMenuSinglePlayer()));
+    connect(computerGame->returnPlayAgainButton(), SIGNAL(clicked()),this,SLOT(switchToSinglePlayerPlayAgain()));
 }
 
 //during the tutorial screen this method is called to switch back to the main menu
@@ -83,12 +85,25 @@ void GameManager::switchBackToMainMenuSinglePlayer() {
     delete computerGame;
 }
 
+//this method allows for the calling of the single player when the play again button is clicked
+void GameManager::switchToSinglePlayerPlayAgain() {
+    switchSinglePlayerScreen();
+    delete computerGame;
+    disconnect(computerGame->returnPlayAgainButton(), SIGNAL(clicked()),this,SLOT(switchToSinglePlayerPlayAgain()));
+}
+
+//this method allows for the calling of the two player when the play again button is clicked
+void GameManager::switchToTwoPlayerPlayAgain() {
+    switchTwoPlayerMode();
+    delete game;
+    disconnect(game->returnPlayAgainButton(), SIGNAL(clicked()),this,SLOT(switchToSinglePlayerPlayAgain()));
+}
+
 //this method is specifically for first run to allow the splash screen to be visible
 void GameManager::timerComplete(){
     Menu menu(&menuScene);
     view.setScene(&menuScene);
     view.show();
-
     //Connecting the button to the library signal clicked, along with the slot switchTwoPlayerMode
     connect(menu.returnTwoPlayerPushButton(),SIGNAL(clicked()),this,SLOT(switchTwoPlayerMode()));
     connect(menu.returnSinglePlayerPushButton(), SIGNAL(clicked()), this, SLOT(switchSinglePlayerScreen()));

--- a/NineMensMorris/src/singleplayergame.cpp
+++ b/NineMensMorris/src/singleplayergame.cpp
@@ -8,11 +8,28 @@ SinglePlayerGame::SinglePlayerGame(QGraphicsScene *scene, bool computerIsWhite) 
         computerPhaseOneMove();
     }
     menuButton = new QPushButton(QString("Main Menu"));
-    menuButton->setGeometry(325,800,150,50);
-    QFont buttonFont("comic sans MS", 14);
+    playAgainButton = new QPushButton(QString("Play Again?"));
+    surrenderButton = new QPushButton(QString("Surrender"));
+    buttonFont = QFont("comic sans MS", 14);
+
     menuButton->setFont(buttonFont);
+    surrenderButton->setFont(buttonFont);
+    playAgainButton->setFont(buttonFont);
+
     menuButton->setStyleSheet("background-color: brown; color: #00DCDC; border-style: outset; border-width: 2px; border-radius: 3px; border-color: yellow; padding: 6px;");
+    playAgainButton->setStyleSheet("background-color: brown; color: #00DCDC; border-style: outset; border-width: 2px; border-radius: 3px; border-color: yellow; padding: 6px;");
+    surrenderButton->setStyleSheet("background-color: brown; color: #00DCDC; border-style: outset; border-width: 2px; border-radius: 3px; border-color: yellow; padding: 6px;");
+
+    surrenderButton->setGeometry(325,750,150,50);
+    menuButton->setGeometry(325,800,150,50);
+    playAgainButton->setGeometry(475,750,150,50);
+
+
     scene->addWidget(menuButton);
+    scene->addWidget(surrenderButton);
+    if (!whiteVictory || !blackVictory) {
+        connect(surrenderButton,SIGNAL(clicked()),this,SLOT(surrenderGame()));
+    }
 }
 //Adds unoccupied spaces to available
 void SinglePlayerGame::scanSpaces() {
@@ -192,3 +209,5 @@ void SinglePlayerGame::nextTurn(Piece *piece) {
         computerCapture();
     }
 }
+
+


### PR DESCRIPTION
# Description

I have added a new surrender mechanic. During the Single Player game one can surrender by clicking the surrender button. After a new button will appear asking to play again or main menu. The Play again button also appears on Two Player mode after the game is over, no surrender in the Two player mode.
![image](https://user-images.githubusercontent.com/71247201/115135619-74bd0480-9fdf-11eb-9584-26ab36b91a4a.png)
I also ensured that the turn ends when the surrender button is pressed:
![image](https://user-images.githubusercontent.com/71247201/115135648-91593c80-9fdf-11eb-90b2-df594a5c1da7.png)


Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes