### PR TITLE
Forfeit mechanic

### DIFF
--- a/NineMensMorris/include/game.h
+++ b/NineMensMorris/include/game.h
@@ -104,8 +104,8 @@ protected:
 private slots:
     void pieceCaptureAction(Piece *piece);
     void pieceSelectAction(Piece *piece);
+    void forfeit();
     virtual void nextTurn(Piece *piece);
-    virtual void forfeit();
 };
 
 #endif // GAME_H

--- a/NineMensMorris/include/game.h
+++ b/NineMensMorris/include/game.h
@@ -24,6 +24,7 @@ public:
     void boardCleanup(QGraphicsProxyWidget* proxyBoard);
     void spaceCleanup(std::vector<Space*> &spaces);
     void textItemCleanup();
+    void buttonCleanup();
 
     int getSpaceIndex(Space *space);
     void setAdjacentSpaces(Piece *piece, bool value);

--- a/NineMensMorris/include/game.h
+++ b/NineMensMorris/include/game.h
@@ -104,7 +104,7 @@ private slots:
     void pieceCaptureAction(Piece *piece);
     void pieceSelectAction(Piece *piece);
     virtual void nextTurn(Piece *piece);
-    void forfeitAgainstComputer();
+    void forfeit();
 };
 
 #endif // GAME_H

--- a/NineMensMorris/include/game.h
+++ b/NineMensMorris/include/game.h
@@ -20,7 +20,6 @@ class Game : public QObject {
 public:
     Game(QGraphicsScene * scene);
     ~Game();
-    QPushButton *menuButton;
     void pieceCleanup(std::vector<Piece*> &pieces);
     void boardCleanup(QGraphicsProxyWidget* proxyBoard);
     void spaceCleanup(std::vector<Space*> &spaces);
@@ -51,6 +50,7 @@ public:
     void endTurn(Piece *piece);
     virtual void startNewTurn();
 
+
     //Functions for testing
     Space *getSpace(int spaceIndex) { return spaceList[spaceIndex]; }
     Piece *getWhitePiece(int pieceIndex) { return whitePieces[pieceIndex]; }
@@ -69,7 +69,12 @@ public:
     QString testInstructionText() { return instructionText->toPlainText(); }
 
     QPushButton *returnMainMenu() {return menuButton;}
+    QPushButton *returnForfeitButton() {return forfeitButton;}
+    QPushButton *returnPlayAgainButton() {return playAgainButton;}
 protected:
+    QPushButton *menuButton;
+    QPushButton *forfeitButton;
+    QPushButton *playAgainButton;
     QGraphicsScene *scene;
     Board *board;
     bool whiteTurn;
@@ -99,7 +104,7 @@ private slots:
     void pieceCaptureAction(Piece *piece);
     void pieceSelectAction(Piece *piece);
     virtual void nextTurn(Piece *piece);
-
+    void forfeitAgainstComputer();
 };
 
 #endif // GAME_H

--- a/NineMensMorris/include/game.h
+++ b/NineMensMorris/include/game.h
@@ -104,7 +104,7 @@ private slots:
     void pieceCaptureAction(Piece *piece);
     void pieceSelectAction(Piece *piece);
     virtual void nextTurn(Piece *piece);
-    void forfeit();
+    virtual void forfeit();
 };
 
 #endif // GAME_H

--- a/NineMensMorris/include/gamemanager.h
+++ b/NineMensMorris/include/gamemanager.h
@@ -39,6 +39,8 @@ private slots:
     void switchBackToMainMenu();
     void switchBackToMainMenuSinglePlayer();
     void switchBackToMainMenuTwoPlayer();
+    void switchPlayAgainTwoPlayer();
+    void switchPlayAgainSinglePlayer();
 };
 
 #endif // GAMEMANAGER_H

--- a/NineMensMorris/include/singleplayergame.h
+++ b/NineMensMorris/include/singleplayergame.h
@@ -29,7 +29,6 @@ private:
     std::vector<int> availableCapture;
 private slots:
     void nextTurn(Piece *piece);
-    void forfeit();
 };
 
 

--- a/NineMensMorris/include/singleplayergame.h
+++ b/NineMensMorris/include/singleplayergame.h
@@ -20,6 +20,7 @@ public:
 
     void startNewTurn();
     QPushButton *returnMainMenu() {return menuButton;}
+    QPushButton *returnPlayAgainButton() {return playAgainButton;}
 private:
     bool computerColorWhite;
     std::vector<int> availableSpaces;

--- a/NineMensMorris/include/singleplayergame.h
+++ b/NineMensMorris/include/singleplayergame.h
@@ -17,7 +17,7 @@ public:
 
     void enableSelectPiece();
     void enableCapturePiece();
-
+    void forfeit();
     void startNewTurn();
     QPushButton *returnMainMenu() {return menuButton;}
     QPushButton *returnPlayAgainButton() {return playAgainButton;}

--- a/NineMensMorris/include/singleplayergame.h
+++ b/NineMensMorris/include/singleplayergame.h
@@ -17,9 +17,10 @@ public:
 
     void enableSelectPiece();
     void enableCapturePiece();
-    void forfeit();
+
     void startNewTurn();
     QPushButton *returnMainMenu() {return menuButton;}
+    QPushButton *returnForfeitButton() {return forfeitButton;}
     QPushButton *returnPlayAgainButton() {return playAgainButton;}
 private:
     bool computerColorWhite;
@@ -28,6 +29,7 @@ private:
     std::vector<int> availableCapture;
 private slots:
     void nextTurn(Piece *piece);
+    void forfeit();
 };
 
 

--- a/NineMensMorris/src/game.cpp
+++ b/NineMensMorris/src/game.cpp
@@ -137,11 +137,22 @@ Game::Game(QGraphicsScene *scene) {
     scene->addItem(blackPieceText);
 
     menuButton = new QPushButton(QString("Main Menu"));
+    forfeitButton = new QPushButton(QString("Forfeit"));
+    playAgainButton = new QPushButton(QString("Play Again?"));
+    forfeitButton->setGeometry(325,750,150,50);
+    playAgainButton->setGeometry(325,750,150,50);
     menuButton->setGeometry(325,800,150,50);
+
     QFont buttonFont("comic sans MS", 14);
     menuButton->setFont(buttonFont);
+    forfeitButton->setFont(buttonFont);
+    playAgainButton->setFont(buttonFont);
     menuButton->setStyleSheet("background-color: brown; color: #00DCDC; border-style: outset; border-width: 2px; border-radius: 3px; border-color: yellow; padding: 6px;");
+    forfeitButton->setStyleSheet("background-color: brown; color: #00DCDC; border-style: outset; border-width: 2px; border-radius: 3px; border-color: yellow; padding: 6px;");
+    playAgainButton->setStyleSheet("background-color: brown; color: #00DCDC; border-style: outset; border-width: 2px; border-radius: 3px; border-color: yellow; padding: 6px;");
+    scene->addWidget(forfeitButton);
     scene->addWidget(menuButton);
+    connect(forfeitButton,SIGNAL(clicked()),this,SLOT(forfeitAgainstComputer()));
 }
 
 // Freeing up piece memory at the end of the game
@@ -364,8 +375,12 @@ void Game::evaluateVictoryConditions() {
     }
     if (whiteVictory) {
         instructionText->setPlainText("White Wins!");
+        scene->removeItem(forfeitButton->graphicsProxyWidget());
+        scene->addWidget(playAgainButton);
     } else if (blackVictory) {
         instructionText->setPlainText("Black Wins!");
+        scene->removeItem(forfeitButton->graphicsProxyWidget());
+        scene->addWidget(playAgainButton);
     }
     else {
         startNewTurn();
@@ -586,4 +601,14 @@ void Game::nextTurn(Piece *piece) {
     if (!captureMode) {
         evaluateVictoryConditions();
     }
+}
+void Game::forfeitAgainstComputer() {
+    disableSelectPiece();
+    disableCapturePiece();
+    if (whiteTurn) {
+        blackVictory = true;
+    } else {
+        whiteVictory = true;
+    }
+    evaluateVictoryConditions();
 }

--- a/NineMensMorris/src/game.cpp
+++ b/NineMensMorris/src/game.cpp
@@ -7,7 +7,7 @@ Game::~Game() {
     Game::spaceCleanup(spaceList);
     Game::textItemCleanup();
     scene->removeItem(board->graphicsProxyWidget());
-    buttonCleanup();
+    Game::buttonCleanup();
     delete board;
 }
 
@@ -182,6 +182,7 @@ void Game::spaceCleanup(std::vector<Space*> &spaces){
     spaces.clear();
 }
 
+//Freeing the button memory at the end of game
 void Game::buttonCleanup() {
     scene->removeItem(forfeitButton->graphicsProxyWidget());
     scene->removeItem(menuButton->graphicsProxyWidget());
@@ -623,6 +624,7 @@ void Game::nextTurn(Piece *piece) {
     }
 }
 
+//forfeit method that depending on the turn the opponent wins, for single player the computer wins
 void Game::forfeit() {
     disableSelectPiece();
     disableCapturePiece();

--- a/NineMensMorris/src/game.cpp
+++ b/NineMensMorris/src/game.cpp
@@ -7,6 +7,8 @@ Game::~Game() {
     Game::spaceCleanup(spaceList);
     Game::textItemCleanup();
     scene->removeItem(board->graphicsProxyWidget());
+    buttonCleanup();
+    delete board;
 }
 
 Game::Game(QGraphicsScene *scene) {
@@ -180,6 +182,15 @@ void Game::spaceCleanup(std::vector<Space*> &spaces){
     spaces.clear();
 }
 
+void Game::buttonCleanup() {
+    scene->removeItem(forfeitButton->graphicsProxyWidget());
+    scene->removeItem(menuButton->graphicsProxyWidget());
+    scene->removeItem(playAgainButton->graphicsProxyWidget());
+    delete forfeitButton;
+    delete menuButton;
+    delete playAgainButton;
+}
+
 void Game::textItemCleanup() {
 /* Remove text items from memory at the end of the game */
     scene->removeItem(titleText);
@@ -187,6 +198,11 @@ void Game::textItemCleanup() {
     scene->removeItem(turnText);
     scene->removeItem(whitePieceText);
     scene->removeItem(blackPieceText);
+    delete blackPieceText;
+    delete whitePieceText;
+    delete titleText;
+    delete instructionText;
+    delete turnText;
 }
 
 int Game::getSpaceIndex(Space *space) {
@@ -379,11 +395,11 @@ void Game::evaluateVictoryConditions() {
     }
     if (whiteVictory) {
         instructionText->setPlainText("White Wins!");
-        scene->removeItem(forfeitButton->graphicsProxyWidget());
+
         scene->addWidget(playAgainButton);
     } else if (blackVictory) {
         instructionText->setPlainText("Black Wins!");
-        scene->removeItem(forfeitButton->graphicsProxyWidget());
+
         scene->addWidget(playAgainButton);
     }
     else {
@@ -606,6 +622,7 @@ void Game::nextTurn(Piece *piece) {
         evaluateVictoryConditions();
     }
 }
+
 void Game::forfeit() {
     disableSelectPiece();
     disableCapturePiece();

--- a/NineMensMorris/src/game.cpp
+++ b/NineMensMorris/src/game.cpp
@@ -139,17 +139,21 @@ Game::Game(QGraphicsScene *scene) {
     menuButton = new QPushButton(QString("Main Menu"));
     forfeitButton = new QPushButton(QString("Forfeit"));
     playAgainButton = new QPushButton(QString("Play Again?"));
+
     forfeitButton->setGeometry(325,750,150,50);
     playAgainButton->setGeometry(325,750,150,50);
     menuButton->setGeometry(325,800,150,50);
 
     QFont buttonFont("comic sans MS", 14);
+
     menuButton->setFont(buttonFont);
     forfeitButton->setFont(buttonFont);
     playAgainButton->setFont(buttonFont);
+
     menuButton->setStyleSheet("background-color: brown; color: #00DCDC; border-style: outset; border-width: 2px; border-radius: 3px; border-color: yellow; padding: 6px;");
     forfeitButton->setStyleSheet("background-color: brown; color: #00DCDC; border-style: outset; border-width: 2px; border-radius: 3px; border-color: yellow; padding: 6px;");
     playAgainButton->setStyleSheet("background-color: brown; color: #00DCDC; border-style: outset; border-width: 2px; border-radius: 3px; border-color: yellow; padding: 6px;");
+
     scene->addWidget(forfeitButton);
     scene->addWidget(menuButton);
     connect(forfeitButton,SIGNAL(clicked()),this,SLOT(forfeitAgainstComputer()));

--- a/NineMensMorris/src/game.cpp
+++ b/NineMensMorris/src/game.cpp
@@ -156,7 +156,7 @@ Game::Game(QGraphicsScene *scene) {
 
     scene->addWidget(forfeitButton);
     scene->addWidget(menuButton);
-    connect(forfeitButton,SIGNAL(clicked()),this,SLOT(forfeitAgainstComputer()));
+    connect(forfeitButton,SIGNAL(clicked()),this,SLOT(forfeit()));
 }
 
 // Freeing up piece memory at the end of the game
@@ -606,7 +606,7 @@ void Game::nextTurn(Piece *piece) {
         evaluateVictoryConditions();
     }
 }
-void Game::forfeitAgainstComputer() {
+void Game::forfeit() {
     disableSelectPiece();
     disableCapturePiece();
     if (whiteTurn) {

--- a/NineMensMorris/src/gamemanager.cpp
+++ b/NineMensMorris/src/gamemanager.cpp
@@ -41,7 +41,7 @@ void GameManager::switchTwoPlayerMode() {
     game = new Game(&gameScene);
     view.setScene(&gameScene);
     connect(game->returnMainMenu(),SIGNAL(clicked()),this,SLOT(switchBackToMainMenuTwoPlayer()));
-
+    connect(game->returnPlayAgainButton(), SIGNAL(clicked()),this, SLOT(switchPlayAgainTwoPlayer()));
 }
 
 //this method begins a single player game with the user being white
@@ -52,6 +52,7 @@ void GameManager::switchComputerPlayerModeWhite() {
 
     //this connect catches the signal if the main menu button is clicked during the game
     connect(computerGame->returnMainMenu(),SIGNAL(clicked()),this,SLOT(switchBackToMainMenuSinglePlayer()));
+    connect(computerGame->returnPlayAgainButton(),SIGNAL(clicked()),this,SLOT(switchPlayAgainSinglePlayer()));
 }
 
 void GameManager::switchComputerPlayerModeBlack() {
@@ -61,6 +62,7 @@ void GameManager::switchComputerPlayerModeBlack() {
 
     //this connect catches the signal if the main menu button is clicked during the game
     connect(computerGame->returnMainMenu(),SIGNAL(clicked()),this,SLOT(switchBackToMainMenuSinglePlayer()));
+    connect(computerGame->returnPlayAgainButton(),SIGNAL(clicked()),this,SLOT(switchPlayAgainSinglePlayer()));
 }
 
 //during the tutorial screen this method is called to switch back to the main menu
@@ -81,6 +83,16 @@ void GameManager::switchBackToMainMenuSinglePlayer() {
     //set the scene back to the menu scene
     view.setScene(&menuScene);
     delete computerGame;
+}
+
+void GameManager::switchPlayAgainTwoPlayer() {
+    delete game;
+    switchTwoPlayerMode();
+}
+
+void GameManager::switchPlayAgainSinglePlayer() {
+    delete computerGame;
+    switchSinglePlayerScreen();
 }
 
 //this method is specifically for first run to allow the splash screen to be visible

--- a/NineMensMorris/src/singleplayergame.cpp
+++ b/NineMensMorris/src/singleplayergame.cpp
@@ -7,7 +7,6 @@ SinglePlayerGame::SinglePlayerGame(QGraphicsScene *scene, bool computerIsWhite) 
     if (computerColorWhite) {
         computerPhaseOneMove();
     }
-    connect(forfeitButton,SIGNAL(clicked()),this,SLOT(forfeit()));
 }
 //Adds unoccupied spaces to available
 void SinglePlayerGame::scanSpaces() {
@@ -186,15 +185,4 @@ void SinglePlayerGame::nextTurn(Piece *piece) {
     } else if (whiteTurn == computerColorWhite) {
         computerCapture();
     }
-}
-
-void SinglePlayerGame::forfeit() {
-    disableCapturePiece();
-    disableSelectPiece();
-    if(computerColorWhite) {
-        whiteVictory = true;
-    } else {
-        blackVictory = true;
-    }
-    evaluateVictoryConditions();
 }

--- a/NineMensMorris/src/singleplayergame.cpp
+++ b/NineMensMorris/src/singleplayergame.cpp
@@ -7,12 +7,6 @@ SinglePlayerGame::SinglePlayerGame(QGraphicsScene *scene, bool computerIsWhite) 
     if (computerColorWhite) {
         computerPhaseOneMove();
     }
-    menuButton = new QPushButton(QString("Main Menu"));
-    menuButton->setGeometry(325,800,150,50);
-    QFont buttonFont("comic sans MS", 14);
-    menuButton->setFont(buttonFont);
-    menuButton->setStyleSheet("background-color: brown; color: #00DCDC; border-style: outset; border-width: 2px; border-radius: 3px; border-color: yellow; padding: 6px;");
-    scene->addWidget(menuButton);
 }
 //Adds unoccupied spaces to available
 void SinglePlayerGame::scanSpaces() {

--- a/NineMensMorris/src/singleplayergame.cpp
+++ b/NineMensMorris/src/singleplayergame.cpp
@@ -7,6 +7,7 @@ SinglePlayerGame::SinglePlayerGame(QGraphicsScene *scene, bool computerIsWhite) 
     if (computerColorWhite) {
         computerPhaseOneMove();
     }
+    connect(forfeitButton,SIGNAL(clicked()),this,SLOT(forfeit()));
 }
 //Adds unoccupied spaces to available
 void SinglePlayerGame::scanSpaces() {
@@ -188,9 +189,12 @@ void SinglePlayerGame::nextTurn(Piece *piece) {
 }
 
 void SinglePlayerGame::forfeit() {
+    disableCapturePiece();
+    disableSelectPiece();
     if(computerColorWhite) {
         whiteVictory = true;
     } else {
         blackVictory = true;
     }
+    evaluateVictoryConditions();
 }

--- a/NineMensMorris/src/singleplayergame.cpp
+++ b/NineMensMorris/src/singleplayergame.cpp
@@ -186,3 +186,11 @@ void SinglePlayerGame::nextTurn(Piece *piece) {
         computerCapture();
     }
 }
+
+void SinglePlayerGame::forfeit() {
+    if(computerColorWhite) {
+        whiteVictory = true;
+    } else {
+        blackVictory = true;
+    }
+}


### PR DESCRIPTION
# Description

I have implemented a forfeit mechanic that works on both single and two player. I have recently decided to overload the forfeit function for the game.cpp for multiple reasons. The number one is that the logic in it works perfectly for the two player mode, but not so much on the computer mode. The thing is that it cares about the current turn and who wins, but on computer mode it should only care about computer winning no matter who's turn it is.

- [x] New feature (non-breaking change which adds functionality)
![image](https://user-images.githubusercontent.com/71247201/115315215-77813c00-a13c-11eb-90be-a767b2efb7f5.png)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings