### PR TITLE
implement move history in UI

### DIFF
--- a/NineMensMorris/include/game.h
+++ b/NineMensMorris/include/game.h
@@ -26,6 +26,7 @@ public:
     void boardCleanup(QGraphicsProxyWidget* proxyBoard);
     void spaceCleanup(std::vector<Space*> &spaces);
     void textItemCleanup();
+    void moveHistoryCleanup();
     void buttonCleanup();
 
     int getSpaceIndex(Space *space);
@@ -102,8 +103,8 @@ protected:
     QGraphicsTextItem *blackPieceText;
     QGraphicsTextItem *instructionalText;
 
-    QLabel *statusLabel;
-    QListWidget *statusContents;
+    QLabel *moveHistoryLabel;
+    QListWidget *moveHistoryContents;
 
     QLabel *columnSpaceLabels[7];
     QLabel *rowSpaceLabels[7];

--- a/NineMensMorris/include/game.h
+++ b/NineMensMorris/include/game.h
@@ -68,7 +68,7 @@ public:
     QString testTurnText() { return turnText->toPlainText(); }
     QString testWhitePieceText() { return whitePieceText->toPlainText(); }
     QString testBlackPieceText() { return blackPieceText->toPlainText(); }
-    QString testInstructionText() { return instructionText->toPlainText(); }
+    QString testInstructionText() { return instructionalText->toPlainText(); }
 
     QPushButton *returnMainMenu() {return menuButton;}
     QPushButton *returnForfeitButton() {return forfeitButton;}
@@ -100,7 +100,7 @@ protected:
     QGraphicsTextItem *turnText;
     QGraphicsTextItem *whitePieceText;
     QGraphicsTextItem *blackPieceText;
-    QGraphicsTextItem *instructionText;
+    QGraphicsTextItem *instructionalText;
 
     QLabel *statusLabel;
     QListWidget *statusContents;

--- a/NineMensMorris/include/game.h
+++ b/NineMensMorris/include/game.h
@@ -36,6 +36,7 @@ public:
     void setTurnCountText(int turn);
     void setPlayerTurnText(bool whitePiece);
     void setInstructionText(int turnNumber, bool captureMode = false);
+    void setMoveHistoryText(Piece *piece);
 
     void checkForNewMill();
     void checkForFlying();
@@ -106,6 +107,8 @@ protected:
 
     QLabel *columnSpaceLabels[7];
     QLabel *rowSpaceLabels[7];
+
+    QMap<int, QString> spaceIndexMap;
 
 private slots:
     void pieceCaptureAction(Piece *piece);

--- a/NineMensMorris/include/game.h
+++ b/NineMensMorris/include/game.h
@@ -5,14 +5,15 @@
 #include "include/piece.h"
 #include "include/board.h"
 
-#include <vector>
-#include <QObject>
+#include <QFont>
 #include <QGraphicsScene>
 #include <QLabel>
-#include <QString>
-#include <QFont>
+#include <QListWidget>
+#include <QObject>
 #include <QPushButton>
+#include <QString>
 #include <QtWidgets/QGraphicsProxyWidget>
+#include <vector>
 
 
 class Game : public QObject {
@@ -100,6 +101,9 @@ protected:
     QGraphicsTextItem *whitePieceText;
     QGraphicsTextItem *blackPieceText;
     QGraphicsTextItem *instructionText;
+
+    QLabel *statusLabel;
+    QListWidget *statusContents;
 
 private slots:
     void pieceCaptureAction(Piece *piece);

--- a/NineMensMorris/include/game.h
+++ b/NineMensMorris/include/game.h
@@ -9,6 +9,7 @@
 #include <QGraphicsScene>
 #include <QLabel>
 #include <QListWidget>
+#include <QMap>
 #include <QObject>
 #include <QPushButton>
 #include <QString>
@@ -102,6 +103,9 @@ protected:
 
     QLabel *statusLabel;
     QListWidget *statusContents;
+
+    QLabel *columnSpaceLabels[7];
+    QLabel *rowSpaceLabels[7];
 
 private slots:
     void pieceCaptureAction(Piece *piece);

--- a/NineMensMorris/src/board.cpp
+++ b/NineMensMorris/src/board.cpp
@@ -2,7 +2,7 @@
 
 Board::Board() {
 /* Constructor for Board class */
-    resize(800,800);
+    resize(800,800); // resizes wooden game board
     setAttribute(Qt::WA_NoSystemBackground);
 }
 

--- a/NineMensMorris/src/board.cpp
+++ b/NineMensMorris/src/board.cpp
@@ -2,7 +2,7 @@
 
 Board::Board() {
 /* Constructor for Board class */
-    resize(800,800); // resizes wooden game board
+    resize(1680,920); // resizes wooden game board
     setAttribute(Qt::WA_NoSystemBackground);
 }
 

--- a/NineMensMorris/src/board.cpp
+++ b/NineMensMorris/src/board.cpp
@@ -12,7 +12,7 @@ void Board::paintEvent(QPaintEvent */*event*/) {
     QPixmap pix(":/images/media/grainy-wood.jpg");
     painter.setBrush(QBrush(pix));
     painter.setPen(QPen(Qt::black,5));
-    painter.drawRect(QRect(50, 0, 700, 670));
+    painter.drawRect(QRect(50,0,700,670));
 
     //Outer square
     chooseLineColor(&painter, 0);
@@ -53,7 +53,6 @@ void Board::paintEvent(QPaintEvent */*event*/) {
     painter.drawLine(500,350,700,350);
     chooseLineColor(&painter, 15);
     painter.drawLine(400,450,400,650);
-
 }
 
 void Board::chooseLineColor(QPainter *painter, int millIndex) {

--- a/NineMensMorris/src/board.cpp
+++ b/NineMensMorris/src/board.cpp
@@ -2,7 +2,7 @@
 
 Board::Board() {
 /* Constructor for Board class */
-    resize(1680,920); // resizes wooden game board
+    resize(1680,920);
     setAttribute(Qt::WA_NoSystemBackground);
 }
 

--- a/NineMensMorris/src/game.cpp
+++ b/NineMensMorris/src/game.cpp
@@ -138,6 +138,21 @@ Game::Game(QGraphicsScene *scene) {
     blackPieceText->setPos(780, 180);
     scene->addItem(blackPieceText);
 
+    // add status label to display list of status messages
+    statusLabel = new QLabel();
+    statusLabel->setText("Status History");
+    statusLabel->setGeometry(QRect(1000, 0, 150, 25));
+    statusLabel->setStyleSheet("background-color: brown; color: #00DCDC; border-style: outset; border-width: 2px; border-radius: 3px; border-color: yellow; padding: 6px;");
+    scene->addWidget(statusLabel);
+
+    // add status list object that stores a list of status messages
+    statusContents = new QListWidget();
+    statusContents->addItem("Ryan has entered the battlefront");
+    statusContents->setWordWrap(true);
+    statusContents->setGeometry(QRect(1000, 50, 200, 200));
+    statusContents->setStyleSheet("background-color: brown; color: #00DCDC; border-style: outset; border-width: 2px; border-radius: 3px; border-color: yellow; padding: 6px;");
+    scene->addWidget(statusContents);
+
     menuButton = new QPushButton(QString("Main Menu"));
     forfeitButton = new QPushButton(QString("Forfeit"));
     playAgainButton = new QPushButton(QString("Play Again?"));

--- a/NineMensMorris/src/game.cpp
+++ b/NineMensMorris/src/game.cpp
@@ -419,6 +419,7 @@ void Game::checkForPieceVictory() {
         }
         if (count < 3) {
             whiteVictory = true;
+            disconnect(forfeitButton,SIGNAL(clicked()),this,SLOT(forfeit()));
         }
     } else {
         for (i = 0; i < whitePieces.size(); i++) {
@@ -428,6 +429,7 @@ void Game::checkForPieceVictory() {
         }
         if (count < 3) {
             blackVictory = true;
+            disconnect(forfeitButton,SIGNAL(clicked()),this,SLOT(forfeit()));
         }
     }
 }
@@ -467,9 +469,11 @@ void Game::checkForMovesVictory() {
     if (count == 0) {
         if (whiteTurn && !blackFlying) {
             whiteVictory = true;
+            disconnect(forfeitButton,SIGNAL(clicked()),this,SLOT(forfeit()));
         }
         else if (!whiteTurn && !whiteFlying) {
             blackVictory = true;
+            disconnect(forfeitButton,SIGNAL(clicked()),this,SLOT(forfeit()));
         }
     }
 }

--- a/NineMensMorris/src/game.cpp
+++ b/NineMensMorris/src/game.cpp
@@ -115,11 +115,11 @@ Game::Game(QGraphicsScene *scene) {
     scene->addItem(titleText);
 
     // add text item for displaying player instructions
-    instructionText = new QGraphicsTextItem("Place your pieces on the board!");
-    instructionText->setFont(statusFont);
-    instructionText->setTextWidth(375);
-    instructionText->setPos(50,700);
-    scene->addItem(instructionText);
+    instructionalText = new QGraphicsTextItem("Place your pieces on the board!");
+    instructionalText->setFont(statusFont);
+    instructionalText->setTextWidth(375);
+    instructionalText->setPos(50,700);
+    scene->addItem(instructionalText);
 
     // add text item for displaying the turn number
     turnText = new QGraphicsTextItem("Turn Number: 1");
@@ -210,14 +210,14 @@ void Game::buttonCleanup() {
 void Game::textItemCleanup() {
 /* Remove text items from memory at the end of the game */
     scene->removeItem(titleText);
-    scene->removeItem(instructionText);
+    scene->removeItem(instructionalText);
     scene->removeItem(turnText);
     scene->removeItem(whitePieceText);
     scene->removeItem(blackPieceText);
     delete blackPieceText;
     delete whitePieceText;
     delete titleText;
-    delete instructionText;
+    delete instructionalText;
     delete turnText;
 }
 
@@ -281,13 +281,13 @@ void Game::setPlayerTurnText(bool whitePiece) {
 void Game::setInstructionText(int turnNumber, bool captureMode) {
 /* Updates instruction text item to assist player in what move they must take */
     if (turnNumber < 9 && !captureMode) {
-        instructionText->setPlainText("Place your pieces on the board!");
+        instructionalText->setPlainText("Place your pieces on the board!");
     }
     else if (turnNumber >= 9 && !captureMode) {
-        instructionText->setPlainText("Move your pieces to form a mill!");
+        instructionalText->setPlainText("Move your pieces to form a mill!");
     }
     else if (captureMode) {
-        instructionText->setPlainText("A mill has been formed! "\
+        instructionalText->setPlainText("A mill has been formed! "\
                                       "Remove an opponent's piece.");
     }
 }
@@ -410,11 +410,11 @@ void Game::evaluateVictoryConditions() {
         checkForPieceVictory();
     }
     if (whiteVictory) {
-        instructionText->setPlainText("White Wins!");
+        instructionalText->setPlainText("White Wins!");
 
         scene->addWidget(playAgainButton);
     } else if (blackVictory) {
-        instructionText->setPlainText("Black Wins!");
+        instructionalText->setPlainText("Black Wins!");
 
         scene->addWidget(playAgainButton);
     }

--- a/NineMensMorris/src/game.cpp
+++ b/NineMensMorris/src/game.cpp
@@ -348,16 +348,16 @@ void Game::setMoveHistoryText(Piece *piece) {
         if (whiteTurn) {
             moveHistoryContents->addItem("White placed a piece on " + spaceCoordinate);
         }
-        else {
-            moveHistoryContents->addItem("Black placed a piece on " + spaceCoordinate + "\n");
+        else if (!whiteTurn) {
+            moveHistoryContents->addItem("Black placed a piece on " + spaceCoordinate);
         }
     }
     else {
         if (whiteTurn) {
-            moveHistoryContents->addItem("White has captured a Black piece on " + spaceCoordinate + "\n");
+            moveHistoryContents->addItem("CAPTURED! White has captured a Black piece on " + spaceCoordinate);
         }
         else {
-            moveHistoryContents->addItem("Black has captured a White piece on " + spaceCoordinate + "\n");
+            moveHistoryContents->addItem("CAPTURED! Black has captured a White piece on " + spaceCoordinate);
         }
     }
     moveHistoryContents->scrollToBottom();

--- a/NineMensMorris/src/game.cpp
+++ b/NineMensMorris/src/game.cpp
@@ -6,6 +6,7 @@ Game::~Game() {
     Game::pieceCleanup(blackPieces);
     Game::spaceCleanup(spaceList);
     Game::textItemCleanup();
+    Game::moveHistoryCleanup();
     scene->removeItem(board->graphicsProxyWidget());
     Game::buttonCleanup();
     delete board;
@@ -133,7 +134,7 @@ Game::Game(QGraphicsScene *scene) {
     for (int i = 0; i < 7; i++) {
         columnSpaceLabels[i] = new QLabel;
         columnSpaceLabels[i]->setText(QString::number(7 - i));
-        columnSpaceLabels[i]->setStyleSheet("color: #00DCDC; padding: 5px;");
+        columnSpaceLabels[i]->setStyleSheet("color: #900603; font-size: 15px; font-weight: bold; padding: 5px;");
         columnSpaceLabels[i]->setAttribute(Qt::WA_TranslucentBackground);
         columnSpaceLabels[i]->setGeometry(715, (100 * i) + 40, 25, 25);
         scene->addWidget(columnSpaceLabels[i]);
@@ -144,7 +145,7 @@ Game::Game(QGraphicsScene *scene) {
         QString letter = QString(i + 65);
         rowSpaceLabels[i] = new QLabel;
         rowSpaceLabels[i]->setText(letter);
-        rowSpaceLabels[i]->setStyleSheet("color: #00DCDC; padding: 5px;");
+        rowSpaceLabels[i]->setStyleSheet("color: #900603; font-size: 15px; font-weight: bold; padding: 5px;");
         rowSpaceLabels[i]->setAttribute(Qt::WA_TranslucentBackground);
         rowSpaceLabels[i]->setGeometry((100 * i) + 90, 10, 25, 25);
         scene->addWidget(rowSpaceLabels[i]);
@@ -186,19 +187,18 @@ Game::Game(QGraphicsScene *scene) {
     scene->addItem(blackPieceText);
 
     // add status label to display list of status messages
-    statusLabel = new QLabel();
-    statusLabel->setText("Move History");
-    statusLabel->setGeometry(QRect(1000, 15, 150, 30));
-    statusLabel->setStyleSheet("background-color: brown; color: #00DCDC; border-style: outset; border-width: 2px; border-radius: 3px; border-color: yellow; padding: 6px;");
-    scene->addWidget(statusLabel);
+    moveHistoryLabel = new QLabel();
+    moveHistoryLabel->setText("Move History");
+    moveHistoryLabel->setGeometry(QRect(1000, 15, 150, 30));
+    moveHistoryLabel->setStyleSheet("background-color: brown; color: #00DCDC; border-style: outset; border-width: 2px; border-radius: 3px; border-color: yellow; padding: 6px;");
+    scene->addWidget(moveHistoryLabel);
 
     // add status list object that stores a list of status messages
-    statusContents = new QListWidget();
-    statusContents->addItem("Ryan has entered the battlefront");
-    statusContents->setWordWrap(true);
-    statusContents->setGeometry(QRect(1000, 50, 300, 350));
-    statusContents->setStyleSheet("background-color: brown; color: #00DCDC; border-style: outset; border-width: 2px; border-radius: 3px; border-color: yellow; padding: 6px;");
-    scene->addWidget(statusContents);
+    moveHistoryContents = new QListWidget();
+    moveHistoryContents->setWordWrap(true);
+    moveHistoryContents->setGeometry(QRect(1000, 50, 300, 350));
+    moveHistoryContents->setStyleSheet("background-color: brown; color: #00DCDC; border-style: outset; border-width: 2px; border-radius: 3px; border-color: yellow; padding: 6px;");
+    scene->addWidget(moveHistoryContents);
 
     menuButton = new QPushButton(QString("Main Menu"));
     forfeitButton = new QPushButton(QString("Forfeit"));
@@ -259,6 +259,14 @@ void Game::textItemCleanup() {
     delete titleText;
     delete instructionalText;
     delete turnText;
+}
+
+void Game::moveHistoryCleanup() {
+/* Remove move history label and text list */
+    scene->removeItem(moveHistoryLabel->graphicsProxyWidget());
+    scene->removeItem(moveHistoryContents->graphicsProxyWidget());
+    delete moveHistoryLabel;
+    delete moveHistoryContents;
 }
 
 int Game::getSpaceIndex(Space *space) {
@@ -333,24 +341,26 @@ void Game::setInstructionText(int turnNumber, bool captureMode) {
 }
 
 void Game::setMoveHistoryText(Piece *piece) {
+/* Update move history text list with recent moves/captures */
     int index = getSpaceIndex(piece->getSpace());
     QString spaceCoordinate = spaceIndexMap[index];
     if (!captureMode) {
         if (whiteTurn) {
-            statusContents->addItem("White placed a piece on " + spaceCoordinate);
+            moveHistoryContents->addItem("White placed a piece on " + spaceCoordinate);
         }
         else {
-            statusContents->addItem("Black placed a piece on " + spaceCoordinate + "\n");
+            moveHistoryContents->addItem("Black placed a piece on " + spaceCoordinate + "\n");
         }
     }
     else {
         if (whiteTurn) {
-            statusContents->addItem("White has captured a Black piece on " + spaceCoordinate);
+            moveHistoryContents->addItem("White has captured a Black piece on " + spaceCoordinate + "\n");
         }
         else {
-            statusContents->addItem("Black has captured a White piece on " + spaceCoordinate);
+            moveHistoryContents->addItem("Black has captured a White piece on " + spaceCoordinate + "\n");
         }
     }
+    moveHistoryContents->scrollToBottom();
 }
 
 void Game::checkForNewMill() {

--- a/NineMensMorris/src/game.cpp
+++ b/NineMensMorris/src/game.cpp
@@ -103,6 +103,27 @@ Game::Game(QGraphicsScene *scene) {
     //Selecting first piece
     selectPiece(whitePieces[0]);
 
+    // Add column labels to game board
+    for (int i = 0; i < 7; i++) {
+        columnSpaceLabels[i] = new QLabel;
+        columnSpaceLabels[i]->setText(QString::number(7 - i));
+        columnSpaceLabels[i]->setStyleSheet("color: #00DCDC; padding: 5px;");
+        columnSpaceLabels[i]->setAttribute(Qt::WA_TranslucentBackground);
+        columnSpaceLabels[i]->setGeometry(715, (100 * i) + 40, 25, 25);
+        scene->addWidget(columnSpaceLabels[i]);
+    }
+
+    // Add row labels to game board
+    for (int i = 0; i < 7; i++) {
+        QString letter = QString(i + 65);
+        rowSpaceLabels[i] = new QLabel;
+        rowSpaceLabels[i]->setText(letter);
+        rowSpaceLabels[i]->setStyleSheet("color: #00DCDC; padding: 5px;");
+        rowSpaceLabels[i]->setAttribute(Qt::WA_TranslucentBackground);
+        rowSpaceLabels[i]->setGeometry((100 * i) + 90, 10, 25, 25);
+        scene->addWidget(rowSpaceLabels[i]);
+    }
+
     // initialize text fonts
     QFont titleFont("Comic Sans MS", 16);
     QFont statusFont("Comic Sans MS", 12);

--- a/NineMensMorris/src/game.cpp
+++ b/NineMensMorris/src/game.cpp
@@ -72,6 +72,32 @@ Game::Game(QGraphicsScene *scene) {
         scene->addWidget(spaceList[i]);
     }
 
+    // Map space indexes to their associated space coordinate
+    spaceIndexMap.insert(0, QString("A1"));
+    spaceIndexMap.insert(1, QString("A4"));
+    spaceIndexMap.insert(2, QString("A7"));
+    spaceIndexMap.insert(3, QString("B2"));
+    spaceIndexMap.insert(4, QString("B4"));
+    spaceIndexMap.insert(5, QString("B6"));
+    spaceIndexMap.insert(6, QString("C3"));
+    spaceIndexMap.insert(7, QString("C4"));
+    spaceIndexMap.insert(8, QString("C5"));
+    spaceIndexMap.insert(9, QString("D1"));
+    spaceIndexMap.insert(10, QString("D2"));
+    spaceIndexMap.insert(11, QString("D3"));
+    spaceIndexMap.insert(12, QString("D5"));
+    spaceIndexMap.insert(13, QString("D6"));
+    spaceIndexMap.insert(14, QString("D7"));
+    spaceIndexMap.insert(15, QString("E3"));
+    spaceIndexMap.insert(16, QString("E4"));
+    spaceIndexMap.insert(17, QString("E5"));
+    spaceIndexMap.insert(18, QString("F2"));
+    spaceIndexMap.insert(19, QString("F4"));
+    spaceIndexMap.insert(20, QString("F6"));
+    spaceIndexMap.insert(21, QString("G1"));
+    spaceIndexMap.insert(22, QString("G4"));
+    spaceIndexMap.insert(23, QString("G7"));
+
     //Adding white pieces
     whitePieces.push_back(new Piece(-30, 225));
     whitePieces.push_back(new Piece(-30, 275));
@@ -161,8 +187,8 @@ Game::Game(QGraphicsScene *scene) {
 
     // add status label to display list of status messages
     statusLabel = new QLabel();
-    statusLabel->setText("Status History");
-    statusLabel->setGeometry(QRect(1000, 0, 150, 25));
+    statusLabel->setText("Move History");
+    statusLabel->setGeometry(QRect(1000, 15, 150, 30));
     statusLabel->setStyleSheet("background-color: brown; color: #00DCDC; border-style: outset; border-width: 2px; border-radius: 3px; border-color: yellow; padding: 6px;");
     scene->addWidget(statusLabel);
 
@@ -170,7 +196,7 @@ Game::Game(QGraphicsScene *scene) {
     statusContents = new QListWidget();
     statusContents->addItem("Ryan has entered the battlefront");
     statusContents->setWordWrap(true);
-    statusContents->setGeometry(QRect(1000, 50, 200, 200));
+    statusContents->setGeometry(QRect(1000, 50, 300, 350));
     statusContents->setStyleSheet("background-color: brown; color: #00DCDC; border-style: outset; border-width: 2px; border-radius: 3px; border-color: yellow; padding: 6px;");
     scene->addWidget(statusContents);
 
@@ -303,6 +329,27 @@ void Game::setInstructionText(int turnNumber, bool captureMode) {
     else if (captureMode) {
         instructionalText->setPlainText("A mill has been formed! "\
                                       "Remove an opponent's piece.");
+    }
+}
+
+void Game::setMoveHistoryText(Piece *piece) {
+    int index = getSpaceIndex(piece->getSpace());
+    QString spaceCoordinate = spaceIndexMap[index];
+    if (!captureMode) {
+        if (whiteTurn) {
+            statusContents->addItem("White placed a piece on " + spaceCoordinate);
+        }
+        else {
+            statusContents->addItem("Black placed a piece on " + spaceCoordinate + "\n");
+        }
+    }
+    else {
+        if (whiteTurn) {
+            statusContents->addItem("White has captured a Black piece on " + spaceCoordinate);
+        }
+        else {
+            statusContents->addItem("Black has captured a White piece on " + spaceCoordinate);
+        }
     }
 }
 
@@ -602,6 +649,7 @@ void Game::endPhaseOne() {
 
 void Game::pieceCaptureAction(Piece *piece) {
 /*Slot for action taken when capturable piece clicked*/
+    setMoveHistoryText(piece);
     scene->removeItem(piece->graphicsProxyWidget());
     piece->getSpace()->setOccupied(false);
     piece->setCaptured(true);
@@ -642,6 +690,7 @@ void Game::pieceSelectAction(Piece *piece) {
 
 void Game::nextTurn(Piece *piece) {
 /*Slot to change the player turn after a move*/
+    setMoveHistoryText(piece);
     endTurn(piece);
     checkForNewMill();
     if (!captureMode) {

--- a/NineMensMorris/src/gamemanager.cpp
+++ b/NineMensMorris/src/gamemanager.cpp
@@ -5,7 +5,7 @@ GameManager::GameManager() {
     Splash splash(&splashScene);
     view.setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
     view.setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
-    view.resize(1100,900);
+    view.resize(1920,1080);
     view.setScene(&splashScene);
     view.show();
 

--- a/NineMensMorris/src/menu.cpp
+++ b/NineMensMorris/src/menu.cpp
@@ -30,7 +30,7 @@ void Menu::mainMenuScreen() {
     computerButton->setStyleSheet("background-color: brown; color: #00DCDC; border-style: outset; border-width: 2px; border-radius: 3px; border-color: yellow; padding: 6px;");
     quitButton->setStyleSheet("background-color: brown; color: #00DCDC; border-style: outset; border-width: 2px; border-radius: 3px; border-color: yellow; padding: 6px;");
     tutorialButton->setStyleSheet("background-color: brown; color: #00DCDC; border-style: outset; border-width: 2px; border-radius: 3px; border-color: yellow; padding: 6px;");
-    gameTitle->setDefaultTextColor(QColor("#00DCDC"));
+    gameTitle->setDefaultTextColor(QColor("#FF4500"));
 
     //set the positioning of each item
     menuBackground = menuBackground.scaled(1920,1080, Qt::IgnoreAspectRatio);

--- a/NineMensMorris/src/menu.cpp
+++ b/NineMensMorris/src/menu.cpp
@@ -12,7 +12,7 @@ void Menu::mainMenuScreen() {
     QFont buttonFont("comic sans MS", 14);
     menuBackground = QPixmap(":/images/media/chimp.jpg");
     int height = 250;
-    int width = scene->width()/2 - gameTitle->boundingRect().width()/2 + 300;
+    int width = scene->width()/2 - gameTitle->boundingRect().width()/2 + 350;
 
     //instantiate the items
     twoPlayerButton = new QPushButton(QString("2-Player"),NULL);
@@ -33,12 +33,12 @@ void Menu::mainMenuScreen() {
     gameTitle->setDefaultTextColor(QColor("#00DCDC"));
 
     //set the positioning of each item
-    menuBackground = menuBackground.scaled(1100,900, Qt::IgnoreAspectRatio);
+    menuBackground = menuBackground.scaled(1400,900, Qt::IgnoreAspectRatio);
     gameTitle->setPos(width,height);
-    computerButton->setGeometry(width+200,height+150,150,70);
-    twoPlayerButton->setGeometry(width+200,height+225,150,70);
-    tutorialButton->setGeometry(width+200,height+300,150,70);
-    quitButton->setGeometry(width+200,height+375,150,70);
+    computerButton->setGeometry(width+150,height+150,150,70);
+    twoPlayerButton->setGeometry(width+150,height+225,150,70);
+    tutorialButton->setGeometry(width+150,height+300,150,70);
+    quitButton->setGeometry(width+150,height+375,150,70);
 
 
     //add items to the scene

--- a/NineMensMorris/src/menu.cpp
+++ b/NineMensMorris/src/menu.cpp
@@ -30,7 +30,7 @@ void Menu::mainMenuScreen() {
     computerButton->setStyleSheet("background-color: brown; color: #00DCDC; border-style: outset; border-width: 2px; border-radius: 3px; border-color: yellow; padding: 6px;");
     quitButton->setStyleSheet("background-color: brown; color: #00DCDC; border-style: outset; border-width: 2px; border-radius: 3px; border-color: yellow; padding: 6px;");
     tutorialButton->setStyleSheet("background-color: brown; color: #00DCDC; border-style: outset; border-width: 2px; border-radius: 3px; border-color: yellow; padding: 6px;");
-    gameTitle->setDefaultTextColor(QColor("#FF4500"));
+    gameTitle->setDefaultTextColor(QColor("brown"));
 
     //set the positioning of each item
     menuBackground = menuBackground.scaled(1920,1080, Qt::IgnoreAspectRatio);

--- a/NineMensMorris/src/menu.cpp
+++ b/NineMensMorris/src/menu.cpp
@@ -12,7 +12,7 @@ void Menu::mainMenuScreen() {
     QFont buttonFont("comic sans MS", 14);
     menuBackground = QPixmap(":/images/media/chimp.jpg");
     int height = 250;
-    int width = scene->width()/2 - gameTitle->boundingRect().width()/2 + 350;
+    int width = scene->width()/2 - gameTitle->boundingRect().width()/2 + 700;
 
     //instantiate the items
     twoPlayerButton = new QPushButton(QString("2-Player"),NULL);
@@ -33,12 +33,12 @@ void Menu::mainMenuScreen() {
     gameTitle->setDefaultTextColor(QColor("#00DCDC"));
 
     //set the positioning of each item
-    menuBackground = menuBackground.scaled(1400,900, Qt::IgnoreAspectRatio);
+    menuBackground = menuBackground.scaled(1920,1080, Qt::IgnoreAspectRatio);
     gameTitle->setPos(width,height);
-    computerButton->setGeometry(width+150,height+150,150,70);
-    twoPlayerButton->setGeometry(width+150,height+225,150,70);
-    tutorialButton->setGeometry(width+150,height+300,150,70);
-    quitButton->setGeometry(width+150,height+375,150,70);
+    computerButton->setGeometry(width+200,height+150,150,70);
+    twoPlayerButton->setGeometry(width+200,height+225,150,70);
+    tutorialButton->setGeometry(width+200,height+300,150,70);
+    quitButton->setGeometry(width+200,height+375,150,70);
 
 
     //add items to the scene

--- a/NineMensMorris/src/singleplayergame.cpp
+++ b/NineMensMorris/src/singleplayergame.cpp
@@ -358,6 +358,7 @@ void SinglePlayerGame::startNewTurn() {
 }
 
 void SinglePlayerGame::nextTurn(Piece *piece) {
+    setMoveHistoryText(piece);
     endTurn(piece);
     checkForNewMill();
     if (!captureMode) {

--- a/NineMensMorris/src/splash.cpp
+++ b/NineMensMorris/src/splash.cpp
@@ -12,7 +12,7 @@ void Splash::splashScreen(){
     QFont nameFont("comic sans MS", 50);
     splashBackground = QPixmap(":/images/media/chimp.jpg");
     int height = scene->height()/2 + 300;
-    int width = scene->width()/2 - teamName->boundingRect().width()/2 + 225;
+    int width = scene->width()/2 - teamName->boundingRect().width()/2 + 340;
 
     // sets the font, style, and color of the text
     teamName->setFont(nameFont);
@@ -24,7 +24,7 @@ void Splash::splashScreen(){
     // sets up the proper spacing and format for the image and lines
     splashBackground = splashBackground.scaled(1100,900, Qt::IgnoreAspectRatio);
     teamName->setPos(width,height);
-    secondLine->setPos(width+250, height+100);
+    secondLine->setPos(width+190, height+100);
 
 
     // adds the items to the scene

--- a/NineMensMorris/src/splash.cpp
+++ b/NineMensMorris/src/splash.cpp
@@ -16,9 +16,9 @@ void Splash::splashScreen(){
 
     // sets the font, style, and color of the text
     teamName->setFont(nameFont);
-    teamName->setDefaultTextColor(QColor("#FF4500"));
+    teamName->setDefaultTextColor(QColor("brown"));
     secondLine->setFont(nameFont);
-    secondLine->setDefaultTextColor(QColor("#FF4500"));
+    secondLine->setDefaultTextColor(QColor("brown"));
 
 
     // sets up the proper spacing and format for the image and lines

--- a/NineMensMorris/src/splash.cpp
+++ b/NineMensMorris/src/splash.cpp
@@ -12,19 +12,19 @@ void Splash::splashScreen(){
     QFont nameFont("comic sans MS", 50);
     splashBackground = QPixmap(":/images/media/chimp.jpg");
     int height = scene->height()/2 + 300;
-    int width = scene->width()/2 - teamName->boundingRect().width()/2 + 340;
+    int width = scene->width()/2 - teamName->boundingRect().width()/2 + 600;
 
     // sets the font, style, and color of the text
     teamName->setFont(nameFont);
-    teamName->setDefaultTextColor(QColor("#00DCDC"));
+    teamName->setDefaultTextColor(QColor("#FF4500"));
     secondLine->setFont(nameFont);
-    secondLine->setDefaultTextColor(QColor("#00DCDC"));
+    secondLine->setDefaultTextColor(QColor("#FF4500"));
 
 
     // sets up the proper spacing and format for the image and lines
-    splashBackground = splashBackground.scaled(1100,900, Qt::IgnoreAspectRatio);
+    splashBackground = splashBackground.scaled(1920,1080, Qt::IgnoreAspectRatio);
     teamName->setPos(width,height);
-    secondLine->setPos(width+190, height+100);
+    secondLine->setPos(width+250, height+100);
 
 
     // adds the items to the scene


### PR DESCRIPTION
# Description

This PR's main implementation is the addition of a QListWidget that stores a history of all the moves made in a single 1-Player or 2-Player game. It will also display the coordinate of any piece that is captured.

![NineMensMorris 5_3_2021 5_03_29 PM](https://user-images.githubusercontent.com/22941799/116939739-7a972480-ac32-11eb-9ad0-46641a4d664d.png)

Further implementation changes:
- Row and column labels, denoting the board's coordinates, has been added
- Splash screen text and title text have been changed to a color better suited for the B/W background
- Game screen is initialized to 1920x1080 resolution
- Deconstruction for newly-added objects has been implemented

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Manually tested.

- [ ] App.test
- [X] Other

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules